### PR TITLE
Add include for click-to-load Youtube elements on voice examples page

### DIFF
--- a/_includes/youtube.html
+++ b/_includes/youtube.html
@@ -1,4 +1,4 @@
-{% if include.start_time %}
+{% if include.start %}
 {% assign yturl = include.ytid | append: "?start=" | append: include.start %}
 {% else %}
 {% assign yturl = include.ytid %}

--- a/_includes/youtube.html
+++ b/_includes/youtube.html
@@ -4,5 +4,5 @@
 {% assign yturl = include.ytid %}
 {% endif %}
 <div id="{{ include.id }}" onclick="buildiframe_yt('{{- include.id -}}','{{- yturl -}}')" class="yt-thumb imghover" style="background-image: url(https://img.youtube.com/vi/{{- include.ytid -}}/0.jpg);">
-  <div class="imgcenter">click to load video</p>
+  <div class="imgcenter">click to load video</div>
 </div>

--- a/_includes/youtube.html
+++ b/_includes/youtube.html
@@ -3,7 +3,6 @@
 {% else %}
 {% assign yturl = include.ytid %}
 {% endif %}
-<div id="{{ include.id }}" onclick="buildiframe_yt('{{- include.id -}}','{{- yturl -}}')" class="yt-thumb imghover">
-  <img src="https://img.youtube.com/vi/{{- include.ytid -}}/0.jpg" alt="click for iframe" class="">
-  <p class="imgcenter">click to load video</p>
+<div id="{{ include.id }}" onclick="buildiframe_yt('{{- include.id -}}','{{- yturl -}}')" class="yt-thumb imghover" style="background-image: url(https://img.youtube.com/vi/{{- include.ytid -}}/0.jpg);">
+  <div class="imgcenter">click to load video</p>
 </div>

--- a/_includes/youtube.html
+++ b/_includes/youtube.html
@@ -4,6 +4,6 @@
 {% assign yturl = include.ytid %}
 {% endif %}
 <div id="{{ include.id }}" onclick="buildiframe_yt('{{- include.id -}}','{{- yturl -}}')" class="yt-thumb imghover">
-  <img src="https://img.youtube.com/vi/{{- includes.ytid -}}/0.jpg" alt="click for iframe" class="">
+  <img src="https://img.youtube.com/vi/{{- include.ytid -}}/0.jpg" alt="click for iframe" class="">
   <p class="imgcenter">click to load video</p>
 </div>

--- a/_includes/youtube.html
+++ b/_includes/youtube.html
@@ -1,0 +1,9 @@
+{% if include.start_time %}
+{% assign yturl = include.ytid | append: "?start=" | append: include.start_time %}
+{% else %}
+{% assign yturl = include.ytid %}
+{% endif %}
+<div id="{{ include.id }}" onclick="buildiframe_yt('{{- include.id -}}','{{- yturl -}}')" class="yt-thumb imghover">
+  <img src="https://img.youtube.com/vi/{{- includes.ytid -}}/0.jpg" alt="click for iframe" class="">
+  <p class="imgcenter">click to load video</p>
+</div>

--- a/_includes/youtube.html
+++ b/_includes/youtube.html
@@ -1,5 +1,5 @@
 {% if include.start_time %}
-{% assign yturl = include.ytid | append: "?start=" | append: include.start_time %}
+{% assign yturl = include.ytid | append: "?start=" | append: include.start %}
 {% else %}
 {% assign yturl = include.ytid %}
 {% endif %}

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -127,22 +127,22 @@ body {
   filter: brightness(40%);
 }
 .imgcenter {
-  position: absolute;
-  top: 0;
-  left: 0;
-  transform: translate(calc(240px - 50%), calc(50% + 100px));
-  font-size: 30px;
+  font-size: 20px;
   color: #eee;
   background: #333;
   padding: 2px 8px 2px 8px;
   border-radius: 8px;
-  font-family: arial;
   opacity: 0.8;
 }
 .yt-thumb {
-  position: relative;
-  max-width: 480px;
-  max-height: 360px;
+  background-repeat: no-repeat;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-size: 100%;
+  aspect-ratio: 4/3;
+  max-width:480px;
+  cursor:pointer;
 }
 
 // ---------------------------------

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -118,10 +118,11 @@ body {
   box-shadow: 4px 4px 20px rgba(40,40,40,0.9);
 }
 
-.yt-embed {
-  width: 100%;
-  aspect-ratio: 16/9;
-  max-width: 560px;
+iframe[title="YouTube video player"] {
+  width:100%;
+  aspect-ratio:16/9;
+  max-width:560px;
+  height:auto;
 }
 .imghover {
   filter: brightness(100%);

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -118,7 +118,11 @@ body {
   box-shadow: 4px 4px 20px rgba(40,40,40,0.9);
 }
 
-
+.yt-embed {
+  width: 100%;
+  aspect-ratio: 16/9;
+  max-width: 560px;
+}
 .imghover {
   filter: brightness(100%);
   transition: all 0.2s ease;

--- a/js/buildiframe.js
+++ b/js/buildiframe.js
@@ -5,7 +5,6 @@ function buildiframe_yt(id="null",src="https://wiki.sumianvoice.com/404") {
   x.outerHTML = `
   <p align="left">
       <iframe
-      class="yt-embed"
       src="https://www.youtube.com/embed/${src}"
       title="YouTube video player"
       frameborder="0"

--- a/js/buildiframe.js
+++ b/js/buildiframe.js
@@ -5,8 +5,7 @@ function buildiframe_yt(id="null",src="https://wiki.sumianvoice.com/404") {
   x.outerHTML = `
   <p align="left">
       <iframe
-      width="560"
-      height="315"
+      class="yt-embed"
       src="https://www.youtube.com/embed/${src}"
       title="YouTube video player"
       frameborder="0"

--- a/wiki/pages/voice-examples/index.md
+++ b/wiki/pages/voice-examples/index.md
@@ -53,7 +53,7 @@ resonance      🎻 🟡 🟡 🟡 🟤 🟤 medium high
 pitch          🎵 🟡 🟡 🟤 🟤 🟤 low (150hz - 250hz intonation, ~500hz peaks)
 difficulty     💔 🟡 🟡 🟡 🟤 🟤 medium hard (bright, buzzy, high intonation peaks)
 ```
-{% include youtube.html id="v-imawonder" ytid="fmgoaFjsqt4" start_time="4409" %}
+{% include youtube.html id="v-imawonder" ytid="fmgoaFjsqt4" start="4409" %}
 <!--  -->
 
 <!--  -->
@@ -111,7 +111,7 @@ resonance      🎻 🟡 🟡 🟡 🟡 🟤 high
 pitch          🎵 🟡 🟡 🟡 🟤 🟤 medium (200hz - 250hz intonation, ~300hz peaks)
 difficulty     💔 🟡 🟡 🟤 🟤 🟤 easy-ish (hard resonance)
 ```
-{% include youtube.html id="v-jimena" ytid="lQWcnKb3BdI" start_time="89" %}
+{% include youtube.html id="v-jimena" ytid="lQWcnKb3BdI" start="89" %}
 <!--  -->
 
 <!--  -->
@@ -130,7 +130,7 @@ resonance      🎻 🟡 🟡 🟡 🟤 🟤 medium-low
 pitch          🎵 🟡 🟡 🟡 🟤 🟤 low-medium (160hz - ~250hz intonation, ~340hz peaks)
 difficulty     💔 🟡 🟡 🟡 🟤 🟤 easy-medium
 ```
-{% include youtube.html id="v-karina" ytid="DYGBmB04SVo" start_time="20" %}
+{% include youtube.html id="v-karina" ytid="DYGBmB04SVo" start="20" %}
 <!--  -->
 
 <!--  -->
@@ -148,7 +148,7 @@ resonance      🎻 🟡 🟡 🟡 🟡 🟤 high
 pitch          🎵 🟡 🟡 🟤 🟤 🟤 low-high (140hz - 350hz intonation)
 difficulty     💔 🟡 🟡 🟡 🟡 🟤 hard - intonation, low pitch
 ```
-{% include youtube.html id="v-jackie" ytid="oOXXuwTPJYQ" start_time="393" %}
+{% include youtube.html id="v-jackie" ytid="oOXXuwTPJYQ" start="393" %}
 <!--  -->
 
 <!--  -->
@@ -184,7 +184,7 @@ resonance      🎻 🟡 🟡 🟡 🟡 🟤 high
 pitch          🎵 🟡 🟤 🟤 🟤 🟤 very low 65 - 150hz
 difficulty     💔 🟡 🟡 🟡 🟤 🟤 hard
 ```
-{% include youtube.html id="v-shohreh" ytid="DGcUB55muSw" start_time="18" %}
+{% include youtube.html id="v-shohreh" ytid="DGcUB55muSw" start="18" %}
 <!--  -->
 
 <!--  -->

--- a/wiki/pages/voice-examples/index.md
+++ b/wiki/pages/voice-examples/index.md
@@ -72,10 +72,7 @@ resonance      🎻 🟡 🟡 🟡 🟡 🟤 medium high
 pitch          🎵 🟡 🟤 🟤 🟤 🟤 very low(120 - 200hz)
 difficulty     💔 🟡 🟡 🟡 🟡 🟤 hard (good glottal behaviour at very very low pitch)
 ```
-<div id="v-nurse" onclick="buildiframe_yt('v-nurse','3u6snmQNTRQ')" class="yt-thumb imghover">
-  <img src="https://img.youtube.com/vi/3u6snmQNTRQ/0.jpg" alt="click for iframe" class="">
-  <p class="imgcenter">click to load video</p>
-</div>
+{% include youtube.html id="v-nurse" ytid="3u6snmQNTRQ" %}
 <!--  -->
 
 <!--  -->
@@ -95,10 +92,7 @@ resonance      🎻 🟡 🟡 🟡 🟡 🟤 high
 pitch          🎵 🟡 🟡 🟡 🟡 🟤 medium-high (170hz - 350hz intonation, ~400hz highest)
 difficulty     💔 🟡 🟡 🟡 🟡 🟤 medium-hard
 ```
-<div id="v-moriah" onclick="buildiframe_yt('v-moriah','UzvqPVx0Jd4')" class="yt-thumb imghover">
-  <img src="https://img.youtube.com/vi/UzvqPVx0Jd4/0.jpg" alt="click for iframe" class="">
-  <p class="imgcenter">click to load video</p>
-</div>
+{% include youtube.html id="v-moriah" ytid="UzvqPVx0Jd4" %}
 <!--  -->
 
 <!--  -->
@@ -117,10 +111,7 @@ resonance      🎻 🟡 🟡 🟡 🟡 🟤 high
 pitch          🎵 🟡 🟡 🟡 🟤 🟤 medium (200hz - 250hz intonation, ~300hz peaks)
 difficulty     💔 🟡 🟡 🟤 🟤 🟤 easy-ish (hard resonance)
 ```
-<div id="v-jimena" onclick="buildiframe_yt('v-jimena','lQWcnKb3BdI?start=89')" class="yt-thumb imghover">
-  <img src="https://img.youtube.com/vi/lQWcnKb3BdI/0.jpg" alt="click for iframe" class="">
-  <p class="imgcenter">click to load video</p>
-</div>
+{% include youtube.html id="v-jimena" ytid="lQWcnKb3BdI" start_time="89" %}
 <!--  -->
 
 <!--  -->
@@ -139,10 +130,7 @@ resonance      🎻 🟡 🟡 🟡 🟤 🟤 medium-low
 pitch          🎵 🟡 🟡 🟡 🟤 🟤 low-medium (160hz - ~250hz intonation, ~340hz peaks)
 difficulty     💔 🟡 🟡 🟡 🟤 🟤 easy-medium
 ```
-<div id="v-karina" onclick="buildiframe_yt('v-karina','DYGBmB04SVo?start=20')" class="yt-thumb imghover">
-  <img src="https://img.youtube.com/vi/DYGBmB04SVo/0.jpg" alt="click for iframe" class="">
-  <p class="imgcenter">click to load video</p>
-</div>
+{% include youtube.html id="v-karina" ytid="DYGBmB04SVo" start_time="20" %}
 <!--  -->
 
 <!--  -->
@@ -159,11 +147,8 @@ vocal weight   🥁 🟡 🟡 🟤 🟤 🟤 low
 resonance      🎻 🟡 🟡 🟡 🟡 🟤 high
 pitch          🎵 🟡 🟡 🟤 🟤 🟤 low-high (140hz - 350hz intonation)
 difficulty     💔 🟡 🟡 🟡 🟡 🟤 hard - intonation, low pitch
-````
-<div id="v-jackie" onclick="buildiframe_yt('v-jackie','oOXXuwTPJYQ?start=393')" class="yt-thumb imghover">
-  <img src="https://img.youtube.com/vi/oOXXuwTPJYQ/0.jpg" alt="click for iframe" class="">
-  <p class="imgcenter">click to load video</p>
-</div>
+```
+{% include youtube.html id="v-jackie" ytid="oOXXuwTPJYQ" start_time="393" %}
 <!--  -->
 
 <!--  -->
@@ -181,10 +166,7 @@ resonance      🎻 🟡 🟡 🟡 🟡 🟤 high
 pitch          🎵 🟡 🟡 🟡 🟡 🟤 170hz- 400hz
 difficulty     💔 🟡 🟡 🟡 🟡 🟤 hard
 ```
-<div id="v-pearlescentmoon" onclick="buildiframe_yt('v-pearlescentmoon','Ke9RcVSdWkg')" class="yt-thumb imghover">
-  <img src="https://img.youtube.com/vi/Ke9RcVSdWkg/0.jpg" alt="click for iframe" class="">
-  <p class="imgcenter">click to load video</p>
-</div>
+{% include youtube.html id="v-pearlescentmoon" ytid="Ke9RcVSdWkg" %}
 <!--  -->
 
 <!--  -->
@@ -202,10 +184,7 @@ resonance      🎻 🟡 🟡 🟡 🟡 🟤 high
 pitch          🎵 🟡 🟤 🟤 🟤 🟤 very low 65 - 150hz
 difficulty     💔 🟡 🟡 🟡 🟤 🟤 hard
 ```
-<div id="v-shohreh" onclick="buildiframe_yt('v-shohreh','DGcUB55muSw?start=18')" class="yt-thumb imghover">
-  <img src="https://img.youtube.com/vi/DGcUB55muSw/0.jpg" alt="click for iframe" class="">
-  <p class="imgcenter">click to load video</p>
-</div>
+{% include youtube.html id="v-shohreh" ytid="DGcUB55muSw" start_time="18" %}
 <!--  -->
 
 <!--  -->
@@ -224,10 +203,7 @@ resonance      🎻 🟡 🟡 🟡 🟤 🟤 medium
 pitch          🎵 🟡 🟡 🟡 🟤 🟤 medium with high intonation (140hz - 270hz, 350hz highs)
 difficulty     💔 🟡 🟡 🟡 🟤 🟤 hard (glottal behaviour)
 ```
-<div id="v-daph" onclick="buildiframe_yt('v-daph','EpM3nWRUqXE')" class="yt-thumb imghover">
-  <img src="https://img.youtube.com/vi/EpM3nWRUqXE/0.jpg" alt="click for iframe" class="">
-  <p class="imgcenter">click to load video</p>
-</div>
+{% include youtube.html id="v-daph" ytid="EpM3nWRUqXE" %}
 <!--  -->
 
 <!--  -->
@@ -245,10 +221,7 @@ resonance      🎻 🟡 🟡 🟡 🟡 🟡 very high (1200hz F1 /a/)
 pitch          🎵 🟡 🟡 🟡 🟡 🟤 very high (230 - 500hz)
 difficulty     💔 🟡 🟡 🟡 🟡 🟡 ridiculous hard
 ```
-<div id="v-mijinko" onclick="buildiframe_yt('v-mijinko','PUbMSqi7F68')" class="yt-thumb imghover">
-  <img src="https://img.youtube.com/vi/PUbMSqi7F68/0.jpg" alt="click for iframe" class="">
-  <p class="imgcenter">click to load video</p>
-</div>
+{% include youtube.html id="v-mijinko" ytid="PUbMSqi7F68" %}
 <!--  -->
 
 <!--  -->
@@ -265,10 +238,7 @@ resonance      🎻 🟡 🟡 🟡 🟤 🟤 medium
 pitch          🎵 🟡 🟡 🟡 🟤 🟤 medium (130 - 150hz with spikes up to 400hz)
 difficulty     💔 🟡 🟡 🟡 🟡 🟡 very hard (glottal behaviour is very smooth)
 ```
-<div id="v-pikat" onclick="buildiframe_yt('v-pikat','IjVd6VdJf2M')" class="yt-thumb imghover">
-  <img src="https://img.youtube.com/vi/IjVd6VdJf2M/0.jpg" alt="click for iframe" class="">
-  <p class="imgcenter">click to load video</p>
-</div>
+{% include youtube.html id="v-pikat" ytid="IjVd6VdJf2M" %}
 <!--  -->
 
 <!--  -->
@@ -286,10 +256,7 @@ resonance      🎻 🟡 🟡 🟡 🟡 🟤 high
 pitch          🎵 🟡 🟡 🟡 🟤 🟤 medium (200 -250hz)
 difficulty     💔 🟡 🟡 🟡 🟤 🟤 medium (resonance and weight)
 ```
-<div id="v-gazes" onclick="buildiframe_yt('v-gazes','1SqetzLJ4Es')" class="yt-thumb imghover">
-  <img src="https://img.youtube.com/vi/1SqetzLJ4Es/0.jpg" alt="click for iframe" class="">
-  <p class="imgcenter">click to load video</p>
-</div>
+{% include youtube.html id="v-gazes" ytid="1SqetzLJ4Es" %}
 <!--  -->
 
 <!--  -->
@@ -307,10 +274,7 @@ resonance      🎻 🟡 🟡 🟡 🟤 🟤 medium
 pitch          🎵 🟡 🟡 🟤 🟤 🟤 low (180-300hz)
 difficulty     💔 🟡 🟡 🟡 🟤 🟤 medium
 ```
-<div id="v-rainbow6" onclick="buildiframe_yt('v-rainbow6','lgk9WQsg5xU')" class="yt-thumb imghover">
-  <img src="https://img.youtube.com/vi/lgk9WQsg5xU/0.jpg" alt="click for iframe" class="">
-  <p class="imgcenter">click to load video</p>
-</div>
+{% include youtube.html id="v-rainbow6" ytid="lgk9WQsg5xU" %}
 <!--  -->
 
 <!--  -->
@@ -329,10 +293,7 @@ resonance      🎻 🟡 🟡 🟡 🟤 🟤 medium
 pitch          🎵 🟡 🟤 🟤 🟤 🟤 very low(100 - 160hz, base ~140hz)
 difficulty     💔 🟡 🟡 🟡 🟡 🟤 hard (good glottal behaviour at very very low pitch)
 ```
-<div id="v-baldurs" onclick="buildiframe_yt('v-baldurs','BcdezgUEnLM')" class="yt-thumb imghover">
-  <img src="https://img.youtube.com/vi/BcdezgUEnLM/0.jpg" alt="click for iframe" class="">
-  <p class="imgcenter">click to load video</p>
-</div>
+{% include youtube.html id="v-baldurs" ytid="BcdezgUEnLM" %}
 <!--  -->
 
 <!--  -->
@@ -350,10 +311,7 @@ resonance      🎻 🟡 🟡 🟡 🟤 🟤 medium high - 900-1200 F1 (~1200 /�
 pitch          🎵 🟡 🟡 🟡 🟤 🟤 medium (200 - 350hz)
 difficulty     💔 🟡 🟡 🟡 🟡 🟤 hard (volume, brightness and resonance)
 ```
-<div id="v-geminitay" onclick="buildiframe_yt('v-geminitay','l-OHb50BzzQ')" class="yt-thumb imghover">
-  <img src="https://img.youtube.com/vi/l-OHb50BzzQ/0.jpg" alt="click for iframe" class="">
-  <p class="imgcenter">click to load video</p>
-</div>
+{% include youtube.html id="v-geminitay" ytid="l-OHb50BzzQ" %}
 <!--  -->
 
 
@@ -382,10 +340,7 @@ resonance      🎻 🟡 🟡 🟡 🟤 🟤 medium
 pitch          🎵 🟡 🟡 🟡 🟤 🟤 medium (130 - 250hz, base ~150hz)
 difficulty     💔 🟡 🟡 🟡 🟤 🟤 medium hard (heavy vocal weight)
 ```
-<div id="v-frankproto" onclick="buildiframe_yt('v-frankproto','I-mWa_GqIEg')" class="yt-thumb imghover">
-  <img src="https://img.youtube.com/vi/I-mWa_GqIEg/0.jpg" alt="click for iframe" class="">
-  <p class="imgcenter">click to load video</p>
-</div>
+{% include youtube.html id="v-frankproto" ytid="I-mWa_GqIEg" %}
 <!--  -->
 
 

--- a/wiki/pages/voice-examples/index.md
+++ b/wiki/pages/voice-examples/index.md
@@ -35,10 +35,7 @@ resonance      🎻 🟡 🟡 🟡 🟡 🟤 medium high
 pitch          🎵 🟡 🟡 🟡 🟤 🟤 low-medium (150hz - 330hz intonation, 500hz highest)
 difficulty     💔 🟡 🟡 🟡 🟤 🟤 easy-medium (brightness at low pitch is hard)
 ```
-<div id="v-waffles" onclick="buildiframe_yt('v-waffles','qjC30KkyLLU')" class="yt-thumb imghover">
-  <img src="https://img.youtube.com/vi/qjC30KkyLLU/0.jpg" alt="click for iframe" class="">
-  <p class="imgcenter">click to load video</p>
-</div>
+{% include youtube.html id="v-waffles" ytid="qjC30KkyLLU" %}
 <!--  -->
 
 <!--  -->
@@ -56,10 +53,7 @@ resonance      🎻 🟡 🟡 🟡 🟤 🟤 medium high
 pitch          🎵 🟡 🟡 🟤 🟤 🟤 low (150hz - 250hz intonation, ~500hz peaks)
 difficulty     💔 🟡 🟡 🟡 🟤 🟤 medium hard (bright, buzzy, high intonation peaks)
 ```
-<div id="v-imawonder" onclick="buildiframe_yt('v-imawonder','fmgoaFjsqt4?start=4409')" class="yt-thumb imghover">
-  <img src="https://img.youtube.com/vi/fmgoaFjsqt4/0.jpg" alt="click for iframe" class="">
-  <p class="imgcenter">click to load video</p>
-</div>
+{% include youtube.html id="v-imawonder" ytid="fmgoaFjsqt4" start_time="4409" %}
 <!--  -->
 
 <!--  -->


### PR DESCRIPTION
## Overview

There was a lot of repetition in the voice examples page regarding the click-to-load video elements so I looked into reducing that.

I did make minor tweaks to the CSS and HTML structure. The containing element now shows the image in its background, and uses flex box to position the "click to load video" element so that the styling doesn't break on smaller screens (e.g. phones).

There are also very minor cosmetic changes (made text slightly smaller, pointer now changes when hovering over element).

The changes are live [here](https://aliialpaca.github.io/TransVoice-Wiki/wiki/pages/voice-examples/) if you want to preview. It otherwise functions pretty much the same to how it did before.

## Changes

- Add `includes/youtube.html` include.
- Change voice examples page to use the include.
- Tweak CSS and HTML slightly of video preview element and "click to load video element" so they don't break with smaller resolutions.
- Add CSS rules targetting the Youtube iframe to attempt to scale the loaded Youtube video with smaller resolutions.