### PR TITLE
Add new page layout to reduce repetition in pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,3 +34,11 @@ gh_edit_repository: "https://github.com/SumianVoice/sumianvoice.github.io" # the
 gh_edit_branch: "main" # the branch that your docs is served from
 # gh_edit_source: docs # the source that your files originate from
 gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into the editor immediately
+
+defaults:
+  -
+    scope:
+      path: "" # an empty string here means all files in the project
+      type: "pages" # previously `post` in Jekyll 2.2.
+    values:
+      layout: "page"

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,7 @@
+---
+layout: default
+---
+
+{% include global.html %}
+
+{{ content }}

--- a/index.md
+++ b/index.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Front Page
 nav_order: 1
 has_children: false

--- a/index.md
+++ b/index.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: Front Page
 nav_order: 1
 has_children: false
 nav_exclude: true
 ---
-{% include global.html %}
 
 # Voice Resource Repository
 This project was started by Sumi and Emma. This is an open resource so if you have additions, suggestions or criticisms they are welcomed.

--- a/test.md
+++ b/test.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: Testing Grounds
 has_children: false
 nav_exclude: true
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/clarity/FVF.md
+++ b/wiki/pages/clarity/FVF.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: FVF
 parent: Clarity
 nav_order: 1
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/clarity/breathiness.md
+++ b/wiki/pages/clarity/breathiness.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: Breathiness
 parent: Clarity
 nav_order: 2
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/clarity/creak.md
+++ b/wiki/pages/clarity/creak.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: Creak
 parent: Clarity
 nav_order: 3
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/clarity/index.md
+++ b/wiki/pages/clarity/index.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: Clarity
 nav_order: 7
 has_children: true
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/clarity/nasality.md
+++ b/wiki/pages/clarity/nasality.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: Nasality
 parent: Clarity
 nav_order: 4
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/clarity/onsets.md
+++ b/wiki/pages/clarity/onsets.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: Onsets
 parent: Clarity
 nav_order: 2
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/clarity/subharmonics.md
+++ b/wiki/pages/clarity/subharmonics.md
@@ -1,11 +1,9 @@
 ---
-layout: default
 title: Subharmonics
 parent: Clarity
 nav_order: 9
 nav_exclude: true
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/communities/index.md
+++ b/wiki/pages/communities/index.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: Voice Communities
 nav_order: 40
 has_children: false
 ---
-{% include global.html %}
 
 # List of Voice Communities
 This is of course not exhaustive! Help us fill this out and add more information about the servers. Contact sumianvoice (gmail) to provide more info or servers or make a pull request. Be sure to add a description of what they do, don't send private servers or servers that don't want to be publicly listed. It is best to ask permission first.

--- a/wiki/pages/disclaimer/index.md
+++ b/wiki/pages/disclaimer/index.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: Legal Disclaimer
 nav_order: 200
 has_children: false
 ---
-{% include global.html %}
 
 # Disclaimer
 All information provided on this site is from community additions. It is provided without warranty, guarantee or liability. By viewing this or any page under wiki.sumianvoice.com, you agree to absolve the site maintainers and contributors of all liability for the content hosted on those pages.

--- a/wiki/pages/getting-started/how-to-practice.md
+++ b/wiki/pages/getting-started/how-to-practice.md
@@ -1,11 +1,9 @@
 ---
-layout: default
 title: How to Practice
 parent: Getting Started
 nav_order: 10
 has_children: false
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/getting-started/index.md
+++ b/wiki/pages/getting-started/index.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: Getting Started
 nav_order: 2
 has_children: true
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/getting-started/pitch.md
+++ b/wiki/pages/getting-started/pitch.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: How Important is Pitch?
 parent: Getting Started
 nav_order: 5
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/getting-started/vocal-gender.md
+++ b/wiki/pages/getting-started/vocal-gender.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: What is Vocal Gender
 parent: Getting Started
 nav_order: 5
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/js-spec/index.md
+++ b/wiki/pages/js-spec/index.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: In-Site Spectrogram
 nav_order: 100
 has_children: false
 ---
-{% include global.html %}
 # In-Site Spectrogram
 There is a js based spectrogram made by Sumi included in the site. It can be found below.
 

--- a/wiki/pages/microbehaviours/index.md
+++ b/wiki/pages/microbehaviours/index.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: Microbehaviours
 nav_order: 20
 has_children: true
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/microbehaviours/microbehaviour-list.md
+++ b/wiki/pages/microbehaviours/microbehaviour-list.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: List of Microbehaviours
 parent: Microbehaviours
 nav_order: 2
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/microbehaviours/mimicry.md
+++ b/wiki/pages/microbehaviours/mimicry.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: Mimicry
 parent: Microbehaviours
 nav_order: 2
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/non-speech/index.md
+++ b/wiki/pages/non-speech/index.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: Non-Speech Features
 nav_order: 27
 has_children: false
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/other-resources/SOVTE.md
+++ b/wiki/pages/other-resources/SOVTE.md
@@ -1,12 +1,10 @@
 ---
-layout: default
 title: SOVTEs
 parent: Other Resources
 nav_order: 3
 has_children: false
 nav_exclude: true
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/other-resources/glossary.md
+++ b/wiki/pages/other-resources/glossary.md
@@ -1,11 +1,9 @@
 ---
-layout: default
 title: Glossary
 parent: Other Resources
 nav_order: 1
 has_children: false
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/other-resources/index.md
+++ b/wiki/pages/other-resources/index.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: Other Resources
 nav_order: 30
 has_children: true
 ---
-{% include global.html %}
 
 # Other Resources
 This category is for various other resources and snippets.

--- a/wiki/pages/other-resources/mechanisms.md
+++ b/wiki/pages/other-resources/mechanisms.md
@@ -1,11 +1,9 @@
 ---
-layout: default
 title: Vocal Mechanisms
 parent: Other Resources
 nav_order: 7
 has_children: false
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/other-resources/pedagogy.md
+++ b/wiki/pages/other-resources/pedagogy.md
@@ -1,11 +1,9 @@
 ---
-layout: default
 title: Pedagogy
 parent: Other Resources
 nav_order: 12
 has_children: false
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/other-resources/questionable-exercises.md
+++ b/wiki/pages/other-resources/questionable-exercises.md
@@ -1,11 +1,9 @@
 ---
-layout: default
 title: Questionable Exercises
 parent: Other Resources
 nav_order: 12
 has_children: false
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/other-resources/questionable-terms.md
+++ b/wiki/pages/other-resources/questionable-terms.md
@@ -1,11 +1,9 @@
 ---
-layout: default
 title: Questionable Terms
 parent: Other Resources
 nav_order: 12
 has_children: false
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/other-resources/spectrograms.md
+++ b/wiki/pages/other-resources/spectrograms.md
@@ -1,11 +1,9 @@
 ---
-layout: default
 title: Spectrograms
 parent: Other Resources
 nav_order: 3
 has_children: false
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/other-resources/vocal-health.md
+++ b/wiki/pages/other-resources/vocal-health.md
@@ -1,12 +1,10 @@
 ---
-layout: default
 title: Vocal Health
 parent: Other Resources
 nav_order: 4
 has_children: false
 nav_exclude: true
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/other-resources/voice-anatomy.md
+++ b/wiki/pages/other-resources/voice-anatomy.md
@@ -1,11 +1,9 @@
 ---
-layout: default
 title: Voice Anatomy
 parent: Other Resources
 nav_order: 11
 has_children: false
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/pitch-range/belting.md
+++ b/wiki/pages/pitch-range/belting.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: Belting
 parent: Pitch Range Expansion
 nav_order: 2
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/pitch-range/index.md
+++ b/wiki/pages/pitch-range/index.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: Pitch Range Expansion
 nav_order: 25
 has_children: true
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/pitch-range/strong-m2.md
+++ b/wiki/pages/pitch-range/strong-m2.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: Strong M2
 parent: Pitch Range Expansion
 nav_order: 2
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/resonance/acoustic-resonance.md
+++ b/wiki/pages/resonance/acoustic-resonance.md
@@ -1,12 +1,10 @@
 ---
-layout: default
 title: Acoustic Resonance
 parent: Big List of Stuff
 nav_order: 19
 has_children: false
 nav_exclude: true
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/resonance/index.md
+++ b/wiki/pages/resonance/index.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: Resonance
 nav_order: 6
 has_children: false
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/speech-patterns/index.md
+++ b/wiki/pages/speech-patterns/index.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: Speech Patterns
 nav_order: 8
 has_children: false
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/various/covert-practice.md
+++ b/wiki/pages/various/covert-practice.md
@@ -1,12 +1,10 @@
 ---
-layout: default
 title: Covert Practice
 parent: Big List of Stuff
 nav_order: 2
 has_children: false
 nav_exclude: false
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/various/hall-of-fame.md
+++ b/wiki/pages/various/hall-of-fame.md
@@ -1,12 +1,10 @@
 ---
-layout: default
 title: Hall of Fame
 parent: Big List of Stuff
 nav_order: 99
 has_children: false
 nav_exclude: false
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/various/hyperadduction.md
+++ b/wiki/pages/various/hyperadduction.md
@@ -1,11 +1,9 @@
 ---
-layout: default
 title: Hyperadduction
 parent: Big List of Stuff
 nav_order: 12
 has_children: false
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/various/index.md
+++ b/wiki/pages/various/index.md
@@ -1,9 +1,7 @@
 ---
-layout: default
 title: Big List of Stuff
 nav_order: 70
 has_children: true
 ---
-{% include global.html %}
 
 Contained within this category is everything that doesn't need to be in the main categories but is still useful information.

--- a/wiki/pages/various/low-fem-voices.md
+++ b/wiki/pages/various/low-fem-voices.md
@@ -1,12 +1,10 @@
 ---
-layout: default
 title: How to do Low Fem Voices
 parent: Big List of Stuff
 nav_order: 8
 has_children: false
 nav_exclude: false
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/various/passages.md
+++ b/wiki/pages/various/passages.md
@@ -1,12 +1,10 @@
 ---
-layout: default
 title: Example Passages
 parent: Big List of Stuff
 nav_order: 10
 has_children: false
 nav_exclude: false
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/vocal-weight/index.md
+++ b/wiki/pages/vocal-weight/index.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: "\nVocal Weight"
 nav_order: 5
 has_children: false
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents

--- a/wiki/pages/voice-examples/index.md
+++ b/wiki/pages/voice-examples/index.md
@@ -1,10 +1,8 @@
 ---
-layout: default
 title: Voice Examples
 nav_order: 18
 has_children: false
 ---
-{% include global.html %}
 <details closed markdown="block">
   <summary>
     Table of contents


### PR DESCRIPTION
This is basically an attempt to do #12 again, but in a much better and vastly simpler way.

Instead of copying the whole of the default layout from the remote theme and making manual changes to it, we just add a new layout (`_layouts/page.html`) inheriting that default layout and then add the global include before the page contents in it.

We then also specify a default front matter variable for all pages in the config so they use this new page layout, so we can remove both the global include and the layout front matter line from every page.

In future PRs the jekyll-toc include from the previous PR could be brought back to remove the TOC from all pages, and maybe we could put the og-tags and construction-notice includes directly in the new layout so we don't need `global.html` anymore, but this is fine for now and doing the changes incrementally makes it nicer to review.

The main changes are in `_config.yml` and `_layouts/page.html`, all the other changes are just removing the now redundant lines in the .md pages.

This PR doesn't result in any visual change. The HTML output should be identical.