### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,18 @@
 
+-- If you plan to copy and use the whole project as a starting point to make and host an
+-- equivalent wiki, please ask permission; we're open to new information, and don't want
+-- to have lots of "the same wiki but slightly different" competing with eachother without
+-- communicating and improving resources. If you feel the need to copy the whole project
+-- and modify some sections of it, the chances are that we would more appreciate your
+-- contributions to this project. This is a request and not a legal demand, as the license
+-- allows any use or modifications so long as the license file is included unmodified.
+-- Just keep in mind that the quality of voice resources depends on open and free
+-- communication of information between communities. The more we have people with
+-- different pedagogy and ideas communicate, the more improvements we can make to
+-- overall voice resource quality. 
+
+--------------
+
 Except where otherwise stated,
 Media is licensed under:
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,36 @@
+
+Except where otherwise stated,
+Media is licensed under:
+
+CC-BY-4.0. https://creativecommons.org/licenses/by/4.0/
+Author: Wiki contributors
+Link:  <https://github.com/SumianVoice/TransVoice-Wiki>
+Year:   2022
+
+--------------
+
+Except where otherwise stated,
+Text content is licensed under:
+
+Modified MIT License
+Original: <https://mit-license.org/>
+
+Copyright (c) 2022 Sumianvoice and Wiki contributors <https://github.com/SumianVoice/TransVoice-Wiki> <https://sumianvoice.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this resource and associated documentation files (the "Resource"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Resource, and to permit persons to whom the Resource is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Resource.
+
+THE RESOURCE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE RESOURCE OR THE USE OR OTHER DEALINGS IN THE
+RESOURCE.


### PR DESCRIPTION
Currently, there is no license, only a disclaimer of liability / warranty. This means that technically, but not practically, people are not allowed to distribute the content of the site for any reason other than fair-use.

This PR is for adding a modified MIT license to the project. This means people can distribute it but must also include the license file attributing back to this site and repository. 

I'm not a fan of licenses at all, so MIT license which is very permissive is probably the best fit here. However, since other people have contributed to the project thus far, I want to get everyone's thoughts and consent to add this license.

The "modified" MIT license has only had the word "software" changed to "resource"